### PR TITLE
Fixed infinite loop in read_dgdl_files

### DIFF
--- a/src/pmx/analysis.py
+++ b/src/pmx/analysis.py
@@ -94,7 +94,7 @@ def read_dgdl_files(lst, lambda0=0, invert_values=False, verbose=True,\
             except:
                 print(' !! Error in checking %s' % (lst[idx]))
                 good=False
-                idx+=1
+        idx+=1
     if(not good):
         raise RuntimeError("No good dgdl files provided.")
 


### PR DESCRIPTION
When all `dhdl.xvg` files have varying lengths, and the longest one has a read error, this would end up in an infinite loop instead of raising a error.